### PR TITLE
Add additional imports

### DIFF
--- a/src/test/java/com/example/springbootupgrade/security/HeaderUserFilterTests.java
+++ b/src/test/java/com/example/springbootupgrade/security/HeaderUserFilterTests.java
@@ -21,6 +21,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.HttpMessageConvertersAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -99,7 +101,8 @@ public class HeaderUserFilterTests {
 
 	@Configuration
 	@Profile("header-user-filter-tests")
-	@ImportAutoConfiguration({ ConfigurationAutoConfiguration.class, CustomSecurityAutoConfiguration.class, SecurityAutoConfiguration.class})
+	@ImportAutoConfiguration({ ConfigurationAutoConfiguration.class, CustomSecurityAutoConfiguration.class, SecurityAutoConfiguration.class,
+			WebMvcAutoConfiguration.class, HttpMessageConvertersAutoConfiguration.class})
 	public static class Config {
 		@Bean
 		public UserDetailsService userDetailsService() {


### PR DESCRIPTION
This is necessary because Spring Security's MVC Matchers require access
to Spring MVC's HandlerMappingIntrospector Bean